### PR TITLE
Fixed issue of index and random number of Math.random()

### DIFF
--- a/05passwordGenerator/src/App.jsx
+++ b/05passwordGenerator/src/App.jsx
@@ -18,7 +18,7 @@ function App() {
     if (charAllowed) str += "!@#$%^&*-_+=[]{}~`"
 
     for (let i = 1; i <= length; i++) {
-      let char = Math.floor(Math.random() * str.length + 1)
+      let char = Math.floor(Math.random() * str.length)
       pass += str.charAt(char)
       
     }


### PR DESCRIPTION
sir, i found an small issue in our passwordgenerator function where we have use Math.random() to generate the random number which is based on the length of string i.e. str.length.
You have used "char = Math.floor(Math.random() * str.length + 1)". 
Here  the random number is generated and then 1 is added to the random number.
For Example 1:  "char = Math.floor(Math.random() * 10 + 1)" --> it will generate random number between 1 to 10

It means the random number which is generated by this "char = Math.floor(Math.random() * str.length + 1)" will be between 1 to str.length.
As we know index starts from 0, the first letter of string will never be included in password and also the last index will be one greater.
What we need is the random number should be between 0 to (str.length-1) so that it can access all the letters of our current string.
So their is minute change in code and it will be "char = Math.floor(Math.random() * str.length )". Now it will give random number between 0 to (str.length-1).