### PR TITLE
Fix for the currency option state

### DIFF
--- a/06currencyConvertor/src/App.jsx
+++ b/06currencyConvertor/src/App.jsx
@@ -46,7 +46,7 @@ function App() {
                             label="From"
                             amount={amount}
                             currencyOptions={options}
-                            onCurrencyChange={(currency) => setAmount(amount)}
+                            onCurrencyChange={(currency) => setFrom(currency)}
                             selectCurrency={from}
                             onAmountChange={(amount) => setAmount(amount)}
                         />


### PR DESCRIPTION
Issue:
The state of the option was not updating when we selected the currency in the From options. Instead, it was selecting the default("USD") value every time.