### PR TITLE
Changed API URL as old URL not working due to minor changes by Author 

### DIFF
--- a/currency.md
+++ b/currency.md
@@ -3,7 +3,11 @@
 ## api link
 
 ```javascript
-let url = `https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/${currency}.json`
+//Invalid URL due to some changes in repository by Author
+// let url = `https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/${currency}.json`
+
+//Valid url as it states under npm now by Author
+let url = `https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/${currency}.json`
 
 ```
 


### PR DESCRIPTION
Old URL output 
![image](https://github.com/user-attachments/assets/258a8da7-d6f8-4087-80b2-cb23912652b1)

Repository migrated by Author
![image](https://github.com/user-attachments/assets/2ef397df-d558-4b40-89b1-12def3e8bb34)

New Repo Link: https://github.com/fawazahmed0/exchange-api/blob/main/MIGRATION.md

URL Endpoints
![image](https://github.com/user-attachments/assets/7e0d05b2-dcc1-4e20-9eca-22ff9e779c75)
