### PR TITLE
fix: updated deprecated currency-api URL

### DIFF
--- a/currency.md
+++ b/currency.md
@@ -3,7 +3,8 @@
 ## api link
 
 ```javascript
-let url = `https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/${currency}.json`
+let url = `https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/${currency}.json
+`
 
 ```
 


### PR DESCRIPTION
Replaced outdated jsDelivr GitHub CDN link with the new npm CDN for currency-api. Fixes fetch failure