### PR TITLE
Update currency.md - updated the link of API for currency

### DIFF
--- a/currency.md
+++ b/currency.md
@@ -3,7 +3,7 @@
 ## api link
 
 ```javascript
-let url = `https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/${currency}.json`
+let url = `https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/{currency}.json`
 
 ```
 


### PR DESCRIPTION
The API previously used to fetch currency data is no longer functional, as the owner has migrated it to a new URL. In this update, the API endpoint has been updated to reflect the new location.